### PR TITLE
fix(sql): migrate interpolated queries to prepared statements

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -174,7 +174,7 @@ function plugin_wmi_create_dataquery_xml($id) {
 		}
 		$data .= "\t\t</items>\n";
 
-		$data_input_data = db_fetch_assoc("SELECT * FROM data_input_fields WHERE data_input_fields.data_input_id=$input AND input_output = 'in' ORDER BY id DESC");
+		$data_input_data = db_fetch_assoc_prepared("SELECT * FROM data_input_fields WHERE data_input_fields.data_input_id=? AND input_output = 'in' ORDER BY id DESC", array($input));
 		$data .= "\t\t<data>\n";
 		$i = 0;
 		if (cacti_sizeof($data_input_data) > 0) {

--- a/poller_wmi.php
+++ b/poller_wmi.php
@@ -236,8 +236,8 @@ function process_all_devices() {
 
 		if (sizeof($dead_devices)) {
 			foreach($dead_devices as $device) {
-				db_execute('DELETE FROM host_wmi_cache WHERE host_id='. $device['host_id']);
-				db_execute('DELETE FROM host_wmi_query WHERE host_id='. $device['host_id']);
+				db_execute_prepared('DELETE FROM host_wmi_cache WHERE host_id=?', array($device['host_id']));
+				db_execute_prepared('DELETE FROM host_wmi_query WHERE host_id=?', array($device['host_id']));
 				print "Purged WMI Device with ID '" . $device['host_id'] . "'" . PHP_EOL;
 			}
 		}


### PR DESCRIPTION
Migrate remaining non-prepared SQL queries that interpolate PHP variables to use prepared statement variants (db_execute_prepared, db_fetch_cell_prepared, etc.). Static SQL without variable interpolation is left as-is.